### PR TITLE
Tag annotations

### DIFF
--- a/emannotationschemas/__init__.py
+++ b/emannotationschemas/__init__.py
@@ -1,4 +1,6 @@
 from emannotationschemas.synapse import SynapseSchema
+from emannotationschemas.tags import BoundTagAnnotation,\
+                                                ReferenceTagAnnotation
 from emannotationschemas.errors import UnknownAnnotationTypeException
 from emannotationschemas.flatten import create_flattened_schema
 from emannotationschemas.bouton_shape import BoutonShape
@@ -8,7 +10,9 @@ __version__ = '0.2.0'
 type_mapping = {
     'synapse': SynapseSchema,
     'bouton_shape': BoutonShape,
-    'functional_coregistration': FunctionalCoregistration
+    'functional_coregistration': FunctionalCoregistration,
+    'bound_tag': BoundTagAnnotation,
+    'reference_tag': ReferenceTagAnnotation
 }
 
 

--- a/emannotationschemas/__init__.py
+++ b/emannotationschemas/__init__.py
@@ -13,6 +13,7 @@ type_mapping = {
     'functional_coregistration': FunctionalCoregistration,
     'bound_tag': BoundTagAnnotation,
 }
+# Get all reference tags
 for ref_type in TypedReferenceTags:
     type_mapping['{}_reference_tag'.format(ref_type)] = TypedReferenceTags[ref_type]
 

--- a/emannotationschemas/__init__.py
+++ b/emannotationschemas/__init__.py
@@ -1,6 +1,6 @@
 from emannotationschemas.synapse import SynapseSchema
 from emannotationschemas.tags import BoundTagAnnotation,\
-                                                ReferenceTagAnnotation
+                                     ReferenceTagAnnotation
 from emannotationschemas.errors import UnknownAnnotationTypeException
 from emannotationschemas.flatten import create_flattened_schema
 from emannotationschemas.bouton_shape import BoutonShape

--- a/emannotationschemas/__init__.py
+++ b/emannotationschemas/__init__.py
@@ -1,6 +1,6 @@
 from emannotationschemas.synapse import SynapseSchema
 from emannotationschemas.tags import BoundTagAnnotation,\
-                                     ReferenceTagAnnotation
+                                     TypedReferenceTags
 from emannotationschemas.errors import UnknownAnnotationTypeException
 from emannotationschemas.flatten import create_flattened_schema
 from emannotationschemas.bouton_shape import BoutonShape
@@ -12,9 +12,9 @@ type_mapping = {
     'bouton_shape': BoutonShape,
     'functional_coregistration': FunctionalCoregistration,
     'bound_tag': BoundTagAnnotation,
-    'reference_tag': ReferenceTagAnnotation
 }
-
+for ref_type in TypedReferenceTags:
+    type_mapping['{}_reference_tag'.format(ref_type)] = TypedReferenceTags[ref_type]
 
 def get_types():
     return [k for k in type_mapping.keys()]

--- a/emannotationschemas/base.py
+++ b/emannotationschemas/base.py
@@ -48,17 +48,6 @@ class ReferenceAnnotation(AnnotationSchema):
         required=True, description='annotation this references')
 
 
-class TagAnnotation(mm.Schema):
-    '''a simple tagged annotation'''
-    tag = mm.fields.Str(
-        required=True, description="tag to attach to annotation")
-
-class ReferenceTagAnnotation(ReferenceAnnotation, TagAnnotation):
-    '''A tag attached to another annotation'''
-
-class BoundTagAnnotation( BoundSpatialPoint, TagAnnotation ):
-    '''A tag attached to a point in space.'''
-
 class SpatialPoint(mm.Schema):
     '''a position in the segmented volume '''
     position = mm.fields.List(mm.fields.Int,

--- a/emannotationschemas/base.py
+++ b/emannotationschemas/base.py
@@ -43,7 +43,7 @@ class AnnotationSchema(mm.Schema):
 
 
 class ReferenceAnnotation(AnnotationSchema):
-    '''a annoation that references another annotation'''
+    '''a annotation that references another annotation'''
     target_id = mm.fields.Int(
         required=True, description='annotation this references')
 
@@ -51,12 +51,13 @@ class ReferenceAnnotation(AnnotationSchema):
 class TagAnnotation(mm.Schema):
     '''a simple tagged annotation'''
     tag = mm.fields.Str(
-        required=True, description="tag to attach to annoation")
-
+        required=True, description="tag to attach to annotation")
 
 class ReferenceTagAnnotation(ReferenceAnnotation, TagAnnotation):
     '''A tag attached to another annotation'''
 
+class BoundTagAnnotation( BoundSpatialPoint, TagAnnotation ):
+    '''A tag attached to a point in space.'''
 
 class SpatialPoint(mm.Schema):
     '''a position in the segmented volume '''

--- a/emannotationschemas/models.py
+++ b/emannotationschemas/models.py
@@ -87,7 +87,7 @@ def make_annotation_model_from_schema(dataset, annotation_type, Schema):
             reference_type = target_field.metadata['reference_type']
             attrd['target_id'] = Column(Integer, ForeignKey(
                 dataset + '_' + reference_type + '.id'))
-            annotation_models[model_name] = type(model_name, (TSBase,), attrd)
+        annotation_models[model_name] = type(model_name, (TSBase,), attrd)
 
     return annotation_models[model_name]
 

--- a/emannotationschemas/tags.py
+++ b/emannotationschemas/tags.py
@@ -2,22 +2,15 @@ from emannotationschemas.base import AnnotationSchema, \
                                      ReferenceAnnotation, \
                                      BoundSpatialPoint
 import marshmallow as mm
+from functools import partial
+
+#Keeps track of the which types of objects for we allow reference tags.
+referenceable_types = ['synapse','bouton_shape','bound_tag','reference_tag']
 
 class TagAnnotation(mm.Schema):
     '''a simple text tag annotation'''
     tag = mm.fields.Str(
         required=True,description="Free text description")
-
-class ReferenceTagAnnotation(ReferenceAnnotation, TagAnnotation):
-    '''A tag attached to another annotation'''
-    target_id = mm.fields.Int(
-        required=True,
-        description='id of object tagged',
-        reference_type='any')
-
-    @mm.post_load
-    def validate_type(self, item):
-        assert item['type'] == 'reference_tag'
 
 class BoundTagAnnotation( AnnotationSchema, TagAnnotation ):
     '''A tag attached to a point in space.'''
@@ -26,3 +19,36 @@ class BoundTagAnnotation( AnnotationSchema, TagAnnotation ):
     @mm.post_load
     def validate_type(self, item):
         assert item['type'] == 'bound_tag'
+
+class ReferenceTagAnnotation(ReferenceAnnotation, TagAnnotation):
+    '''A tag attached to another annotation'''
+    target_id = mm.fields.Int(
+        required=True,
+        description='id of object tagged',
+        reference_type="fill_in_with_reference_type"
+        )
+
+    valid_type = 'specify_valid_type'
+    @mm.post_load
+    def validate_type(self, item):
+        assert item['type'] == self.valid_type
+
+@mm.post_load
+def validate_type_helper( self, item, reference_tag_type ):
+    assert item['type'] == reference_tag_type
+
+def typed_reference_tag_factory(reference_type, ReferenceSchema ):
+    new_tag_name = '{}_reference_tag'.format(reference_type)
+    new_attrd = dict(ReferenceSchema.__dict__)
+    new_attrd['_declared_fields']['target_id'] = mm.fields.Int(
+                                    required=True,
+                                    description='id of object tagged',
+                                    reference_type=reference_type
+                                    )
+    new_attrd['valid_type'] = new_tag_name
+    print(new_tag_name)
+    return type(new_tag_name, (ReferenceSchema,), new_attrd)
+
+TypedReferenceTags = {}
+for ref_type in referenceable_types:
+    TypedReferenceTags[ref_type] = typed_reference_tag_factory(ref_type, ReferenceTagAnnotation)

--- a/emannotationschemas/tags.py
+++ b/emannotationschemas/tags.py
@@ -6,16 +6,23 @@ import marshmallow as mm
 class TagAnnotation(mm.Schema):
     '''a simple text tag annotation'''
     tag = mm.fields.Str(
-        required=True, description="Free text description")
+        required=True,description="Free text description")
 
-class ReferenceTagAnnotation(AnnotationSchema, ReferenceAnnotation, TagAnnotation):
+class ReferenceTagAnnotation(ReferenceAnnotation, TagAnnotation):
     '''A tag attached to another annotation'''
+    target_id = mm.fields.Int(
+        required=True,
+        description='id of object tagged',
+        reference_type='any')
+
     @mm.post_load
     def validate_type(self, item):
         assert item['type'] == 'reference_tag'
 
-class BoundTagAnnotation(AnnotationSchema, BoundSpatialPoint, TagAnnotation ):
+class BoundTagAnnotation( AnnotationSchema, TagAnnotation ):
     '''A tag attached to a point in space.'''
+    pt = mm.fields.Nested( BoundSpatialPoint, required=True,
+                           description='Location associated with tag')
     @mm.post_load
     def validate_type(self, item):
         assert item['type'] == 'bound_tag'

--- a/emannotationschemas/tags.py
+++ b/emannotationschemas/tags.py
@@ -4,7 +4,7 @@ from emannotationschemas.base import AnnotationSchema, \
 import marshmallow as mm
 from functools import partial
 
-#Keeps track of the which types of objects for we allow reference tags.
+#Keeps track of the which types of objects are allowed reference tags. Must be a table in materialization.
 referenceable_types = ['synapse','bouton_shape','bound_tag','reference_tag']
 
 class TagAnnotation(mm.Schema):
@@ -46,7 +46,6 @@ def typed_reference_tag_factory(reference_type, ReferenceSchema ):
                                     reference_type=reference_type
                                     )
     new_attrd['valid_type'] = new_tag_name
-    print(new_tag_name)
     return type(new_tag_name, (ReferenceSchema,), new_attrd)
 
 TypedReferenceTags = {}

--- a/emannotationschemas/tags.py
+++ b/emannotationschemas/tags.py
@@ -1,0 +1,21 @@
+from emannotationschemas.base import AnnotationSchema, \
+                                     ReferenceAnnotation, \
+                                     BoundSpatialPoint
+import marshmallow as mm
+
+class TagAnnotation(mm.Schema):
+    '''a simple text tag annotation'''
+    tag = mm.fields.Str(
+        required=True, description="Free text description")
+
+class ReferenceTagAnnotation(AnnotationSchema, ReferenceAnnotation, TagAnnotation):
+    '''A tag attached to another annotation'''
+    @mm.post_load
+    def validate_type(self, item):
+        assert item['type'] == 'reference_tag'
+
+class BoundTagAnnotation(AnnotationSchema, BoundSpatialPoint, TagAnnotation ):
+    '''A tag attached to a point in space.'''
+    @mm.post_load
+    def validate_type(self, item):
+        assert item['type'] == 'bound_tag'

--- a/emannotationschemas/tags.py
+++ b/emannotationschemas/tags.py
@@ -5,7 +5,7 @@ import marshmallow as mm
 from functools import partial
 
 #Keeps track of the which types of objects are allowed reference tags. Must be a table in materialization.
-referenceable_types = ['synapse','bouton_shape','bound_tag','reference_tag']
+referenceable_types = ['synapse','bound_tag','reference_tag']
 
 class TagAnnotation(mm.Schema):
     '''a simple text tag annotation'''

--- a/test/test_tags.py
+++ b/test/test_tags.py
@@ -1,10 +1,17 @@
-from emannotationschemas.tags import BoundTagAnnotation, ReferenceTagAnnotation
+from emannotationschemas.tags import BoundTagAnnotation, TypedReferenceTags
 
-reference_tag= {
-    'type': 'reference_tag',
-    'tag' : "This tag points at an object",
+synapse_reference_tag_data = {
+    'type': 'synapse_reference_tag',
+    'tag' : "This tag points at a synapse",
     'target_id': 98109,
-    'reference_type': 'any'
+    'reference_type': 'synapse_reference_tag'
+}
+
+reference_tag_reference_tag_data = {
+    'type': 'reference_tag_reference_tag',
+    'tag' : "This tag points at a reference tag",
+    'target_id': 98109,
+    'reference_type': 'reference_tag_reference_tag'
 }
 
 bound_tag = {
@@ -17,12 +24,23 @@ def annotation_import(item):
     item['supervoxel_id'] = 5
     item.pop('rootId', None)
 
-def test_reference_tag():
-    schema = ReferenceTagAnnotation()
-    result = schema.load( reference_tag )
-    assert( result.data['tag'][-6:] == 'object' )
-
 def test_bound_tag():
     schema = BoundTagAnnotation(context={'bsp_fn':annotation_import})
     result = schema.load( bound_tag )
-    assert( result.data['pt']['supervoxel_id'] == 5)
+    assert result.data['pt']['supervoxel_id'] == 5
+
+def test_proper_reference_tag():
+    schema = TypedReferenceTags['synapse']()
+    result = schema.load( synapse_reference_tag_data )
+    assert result.data['tag'][-7:] == 'synapse' 
+
+    schema = TypedReferenceTags['reference_tag']()
+    result = schema.load( reference_tag_reference_tag_data )
+    assert result.data['tag'][-3:] == 'tag' 
+
+def test_improper_reference_tag():
+    schema = TypedReferenceTags['synapse']()
+    try:
+        result = schema.load( reference_tag_reference_tag_data )
+    except AssertionError:
+        assert True

--- a/test/test_tags.py
+++ b/test/test_tags.py
@@ -42,5 +42,6 @@ def test_improper_reference_tag():
     schema = TypedReferenceTags['synapse']()
     try:
         result = schema.load( reference_tag_reference_tag_data )
+        assert False
     except AssertionError:
         assert True

--- a/test/test_tags.py
+++ b/test/test_tags.py
@@ -1,0 +1,28 @@
+from emannotationschemas.tags import BoundTagAnnotation, ReferenceTagAnnotation
+
+reference_tag= {
+    'type': 'reference_tag',
+    'tag' : "This tag points at an object",
+    'target_id': 98109,
+    'reference_type': 'any'
+}
+
+bound_tag = {
+    'type': 'bound_tag',
+    'tag': 'This tag points to a location in space',
+    'pt': {'position': [1,2,3]}
+}
+
+def annotation_import(item):
+    item['supervoxel_id'] = 5
+    item.pop('rootId', None)
+
+def test_reference_tag():
+    schema = ReferenceTagAnnotation()
+    result = schema.load( reference_tag )
+    assert( result.data['tag'][-6:] == 'object' )
+
+def test_bound_tag():
+    schema = BoundTagAnnotation(context={'bsp_fn':annotation_import})
+    result = schema.load( bound_tag )
+    assert( result.data['pt']['supervoxel_id'] == 5)


### PR DESCRIPTION
Schema for descriptive, unstructured text tags that point at either a point in space or an annotation. Materialization needs to use the type of the reference object to use it as a correct foreign key, so there needs to be a reference annotation for each type we want to be able to be referenced. The current implementation generates these dynamically based on a list in `tags.py`.