### PR TITLE
altering SQLAlchemy models to assume a new database for every version

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.3
+current_version = 1.1.4
 commit = True
 tag = True
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.4
+current_version = 2.0.0
 commit = True
 tag = True
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ cache:
 
 jobs:
   include:
-    - python: 3.5
     - python: 3.6
       after_success:
         - codecov

--- a/emannotationschemas/__init__.py
+++ b/emannotationschemas/__init__.py
@@ -9,7 +9,7 @@ from emannotationschemas.cell_type_local import CellTypeLocal
 from emannotationschemas.bound_text_tag import BoundTagAnnotation
 from emannotationschemas.extended_classical_cell_type import ExtendedClassicalCellType
 
-__version__ = '1.1.3'
+__version__ = '1.1.4'
 
 type_mapping = {
     'synapse': SynapseSchema,

--- a/emannotationschemas/__init__.py
+++ b/emannotationschemas/__init__.py
@@ -9,7 +9,7 @@ from emannotationschemas.cell_type_local import CellTypeLocal
 from emannotationschemas.bound_text_tag import BoundTagAnnotation
 from emannotationschemas.extended_classical_cell_type import ExtendedClassicalCellType
 
-__version__ = '1.1.4'
+__version__ = '2.0.0'
 
 type_mapping = {
     'synapse': SynapseSchema,

--- a/emannotationschemas/blueprint_app.py
+++ b/emannotationschemas/blueprint_app.py
@@ -5,7 +5,7 @@ from emannotationschemas import get_schema, get_types
 
 
 bp = Blueprint("schema", __name__, url_prefix="/schema")
-__version__ = '1.1.3'
+__version__ = '1.1.4'
 
 
 @bp.route("")

--- a/emannotationschemas/blueprint_app.py
+++ b/emannotationschemas/blueprint_app.py
@@ -5,7 +5,7 @@ from emannotationschemas import get_schema, get_types
 
 
 bp = Blueprint("schema", __name__, url_prefix="/schema")
-__version__ = '1.1.4'
+__version__ = '2.0.0'
 
 
 @bp.route("")

--- a/emannotationschemas/models.py
+++ b/emannotationschemas/models.py
@@ -16,23 +16,9 @@ Base = declarative_base()
 root_model_name = "CellSegment"
 
 
-def get_next_version(sql_uri, dataset_name):
-    engine = create_engine(sql_uri)
-    versions = np.array([get_table_version(t)
-                         for t in engine.table_names() if (dataset_name in t)])
-    if len(versions) > 0:
-        new_version = np.max(versions)+1
-    else:
-        new_version = 0
-    return new_version
-
-
 def format_table_name(dataset, table_name, version: int = 1):
-    return "{}_{}_v{}".format(dataset, table_name, version)
-
-
-def get_table_version(table_name):
-    return int(table_name.split('_')[-1][1:])
+    return table_name
+    #return "{}_{}_v{}".format(dataset, table_name, version)
 
 
 class ModelStore():

--- a/emannotationschemas/models.py
+++ b/emannotationschemas/models.py
@@ -1,24 +1,34 @@
 from sqlalchemy import Column, String, Integer, Float, Numeric, Boolean, \
-    create_engine, DateTime, ForeignKey
+     DateTime, ForeignKey
 from sqlalchemy.orm import relationship
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.ext.declarative import AbstractConcreteBase
 from geoalchemy2 import Geometry
 from emannotationschemas import get_schema, get_types
 from emannotationschemas.base import NumericField, ReferenceAnnotation
 from emannotationschemas.contact import Contact
-from emannotationschemas.errors import UnknownAnnotationTypeException, InvalidTableMetaDataException
+from emannotationschemas.errors import UnknownAnnotationTypeException, \
+                                       InvalidTableMetaDataException
 import marshmallow as mm
-import numpy as np
 
 Base = declarative_base()
 
 root_model_name = "CellSegment"
 
 
+def format_database_name(dataset, version):
+    return f"{dataset}_v{version}"
+
+
+def format_version_db_uri(sql_uri, dataset, version):
+    sql_uri_base = "/".join(sql_uri.split('/')[:-1])
+    new_db_name = format_database_name(dataset, version)
+    version_db_uri = sql_uri_base + f"/{new_db_name}"
+    return version_db_uri
+
+
 def format_table_name(dataset, table_name, version: int = 1):
     return table_name
-    #return "{}_{}_v{}".format(dataset, table_name, version)
+    # return "{}_{}_v{}".format(dataset, table_name, version)
 
 
 class ModelStore():


### PR DESCRIPTION
This is a breaking change, allows interfacing with a database that has only one set of tables for one version. Needed to enable efficient incremental materialization.