### PR TITLE
add plastic synapse

### DIFF
--- a/emannotationschemas/__init__.py
+++ b/emannotationschemas/__init__.py
@@ -1,4 +1,4 @@
-from emannotationschemas.synapse import SynapseSchema
+from emannotationschemas.synapse import SynapseSchema, PlasticSynapse
 from emannotationschemas.errors import UnknownAnnotationTypeException
 from emannotationschemas.flatten import create_flattened_schema
 from emannotationschemas.presynaptic_bouton_type import PresynapticBoutonType
@@ -20,6 +20,7 @@ type_mapping = {
     'flat_segmentation_reference': FlatSegmentationReference,
     'bound_tag': BoundTagAnnotation,
     'extended_classical_cell_type': ExtendedClassicalCellType,
+    'plastic_synapse': PlasticSynapse
 }
 
 

--- a/emannotationschemas/synapse.py
+++ b/emannotationschemas/synapse.py
@@ -37,3 +37,9 @@ class SynapseSchema(AnnotationSchema):
         else:
             item.pop('valid', None)
         return item
+
+
+class PlasticSynapse(SynapseSchema):
+    plasticity = mm.fields.Int(required=True,
+                               validate=mm.validate.OneOf([0, 1, 2, 3, 4]),
+                               description="plasticity state 0:not synapse 1:normal 2:mild 3:strong 4:not rated")


### PR DESCRIPTION
adding a schema for synapses with plasticity tags (ideally this would be a reference annotation) although this allows for plasticity marks that are not tied to any particular synapse detection table.. which does have some advantages.