### PR TITLE
Simple derived point

### DIFF
--- a/emannotationschemas/__init__.py
+++ b/emannotationschemas/__init__.py
@@ -9,6 +9,7 @@ from emannotationschemas.schemas.glia_contact import GliaContact
 from emannotationschemas.schemas.contact import Contact
 from emannotationschemas.schemas.extended_classical_cell_type import ExtendedClassicalCellType
 from emannotationschemas.schemas.nucleus_detection import NucleusDetection
+from emannotationschemas.schemas.derived_spatial_point import DerivedSpatialPoint, DerivedSpatialTag
 from emannotationschemas.errors import UnknownAnnotationTypeException
 from emannotationschemas.flatten import create_flattened_schema
 
@@ -26,6 +27,8 @@ type_mapping = {
     'plastic_synapse': PlasticSynapse,
     'glia_contact': GliaContact,
     'contact': Contact,
+    'derived_spatial_point': DerivedSpatialPoint,
+    'derived_tag': DerivedSpatialTag,
 }
 
 
@@ -76,7 +79,7 @@ def create_app(test_config=None):
     from emannotationschemas.config import configure_app
     from emannotationschemas.utils import get_instance_folder_path
 
-    from emannotationschemas.blueprint_app import api_bp 
+    from emannotationschemas.blueprint_app import api_bp
     from emannotationschemas.views import views_bp
     import logging
     # Define the Flask Object
@@ -94,7 +97,8 @@ def create_app(test_config=None):
 
     apibp = Blueprint('api', __name__, url_prefix='/schema/api')
     with app.app_context():
-        api = Api(apibp, title="EMAnnotationSchemas API", version=__version__, doc="/doc")
+        api = Api(apibp, title="EMAnnotationSchemas API",
+                  version=__version__, doc="/doc")
         api.add_namespace(api_bp, path='/v2')
         app.register_blueprint(apibp)
         app.register_blueprint(views_bp)

--- a/emannotationschemas/__init__.py
+++ b/emannotationschemas/__init__.py
@@ -9,7 +9,7 @@ from emannotationschemas.schemas.glia_contact import GliaContact
 from emannotationschemas.schemas.contact import Contact
 from emannotationschemas.schemas.extended_classical_cell_type import ExtendedClassicalCellType
 from emannotationschemas.schemas.nucleus_detection import NucleusDetection
-from emannotationschemas.schemas.derived_spatial_point import DerivedSpatialPoint, DerivedSpatialTag
+from emannotationschemas.schemas.derived_spatial_point import DerivedSpatialPoint, DerivedTag
 from emannotationschemas.errors import UnknownAnnotationTypeException
 from emannotationschemas.flatten import create_flattened_schema
 
@@ -28,7 +28,7 @@ type_mapping = {
     'glia_contact': GliaContact,
     'contact': Contact,
     'derived_spatial_point': DerivedSpatialPoint,
-    'derived_tag': DerivedSpatialTag,
+    'derived_tag': DerivedTag,
 }
 
 

--- a/emannotationschemas/schemas/derived_spatial_point.py
+++ b/emannotationschemas/schemas/derived_spatial_point.py
@@ -2,16 +2,10 @@ from emannotationschemas.schemas.base import BoundSpatialPoint, NumericField, An
 import marshmallow as mm
 
 
-class DerivedSpatialPoint(BoundSpatialPoint, AnnotationSchema):
+class DerivedSpatialPoint(BoundSpatialPoint):
     dependent_chunk = NumericField(description='Layer 2 chunk id for the point at the time the annotation was made',
                                    required=True,
                                    segment=True)
-    valid = mm.fields.Bool(
-        required=False,
-        description="is this annotation valid",
-        default=True,
-        missing=True,
-    )
 
 
 class DerivedTag(AnnotationSchema):

--- a/emannotationschemas/schemas/derived_spatial_point.py
+++ b/emannotationschemas/schemas/derived_spatial_point.py
@@ -1,13 +1,20 @@
-from emannotationschemas.schemas.base import BoundSpatialPoint, AnnotationSchema
+from emannotationschemas.schemas.base import BoundSpatialPoint, NumericField, AnnotationSchema
 import marshmallow as mm
 
 
-class DerivedSpatialPoint(AnnotationSchema):
-    pt = mm.fields.Nested(BoundSpatialPoint, required=True,
-                          description="Location of annotated point")
-    chunk_id = mm.fields.Int(required=True,
-                             description="Layer 2 chunk id annotation depends on. If current layer 2 id differs, this annotation is potentially out of date")
+class DerivedSpatialPoint(BoundSpatialPoint, AnnotationSchema):
+    dependent_chunk = NumericField(description='Layer 2 chunk id for the point at the time the annotation was made',
+                                   required=True,
+                                   segment=True)
+    valid = mm.fields.Bool(
+        required=False,
+        description="is this annotation valid",
+        default=True,
+        missing=True,
+    )
 
 
-class DerivedSpatialTag(DerivedSpatialPoint):
-    tag = mm.fields.String(required=True, description="Descriptive text")
+class DerivedTag(AnnotationSchema):
+    '''Basic spatial tag using DerivedSpatialPoint information'''
+    pt = mm.fields.Nested(DerivedSpatialPoint, required=True)
+    tag = mm.fields.String(required=True, description="Description of point")

--- a/emannotationschemas/schemas/derived_spatial_point.py
+++ b/emannotationschemas/schemas/derived_spatial_point.py
@@ -1,0 +1,13 @@
+from emannotationschemas.schemas.base import BoundSpatialPoint, AnnotationSchema
+import marshmallow as mm
+
+
+class DerivedSpatialPoint(AnnotationSchema):
+    pt = mm.fields.Nested(BoundSpatialPoint, required=True,
+                          description="Location of annotated point")
+    chunk_id = mm.fields.Int(required=True,
+                             description="Layer 2 chunk id annotation depends on. If current layer 2 id differs, this annotation is potentially out of date")
+
+
+class DerivedSpatialTag(DerivedSpatialPoint):
+    tag = mm.fields.String(required=True, description="Descriptive text")

--- a/emannotationschemas/schemas/derived_spatial_point.py
+++ b/emannotationschemas/schemas/derived_spatial_point.py
@@ -3,9 +3,10 @@ import marshmallow as mm
 
 
 class DerivedSpatialPoint(BoundSpatialPoint):
-    dependent_chunk = NumericField(description='Layer 2 chunk id for the point at the time the annotation was made',
-                                   required=True,
-                                   segment=True)
+    dependent_chunk = NumericField(description='Chunk id for the point at the time the annotation was made',
+                                   required=True)
+    level = NumericField(description='Chunk level',
+                         required=False)
 
 
 class DerivedTag(AnnotationSchema):


### PR DESCRIPTION
Derived points should be a subclass of BoundSpatialPoints with initial chunk id and a validation column that can be invalidated in a future materialization. We need to think about a good way to generate the level 2 id since it won't necessarily be the same as the value at annotation upload (although that would be a useful backup function to add to materialization, similar to `bsp_fn` is now).