### PR TITLE
Adding schema for fly synapses

### DIFF
--- a/emannotationschemas/__init__.py
+++ b/emannotationschemas/__init__.py
@@ -1,4 +1,4 @@
-from emannotationschemas.synapse import SynapseSchema, PlasticSynapse, BuhmannSynapseSchema
+from emannotationschemas.synapse import SynapseSchema, PlasticSynapse, BuhmannSynapseSchema, BuhmannEcksteinSchema
 from emannotationschemas.errors import UnknownAnnotationTypeException
 from emannotationschemas.flatten import create_flattened_schema
 from emannotationschemas.presynaptic_bouton_type import PresynapticBoutonType
@@ -15,7 +15,7 @@ __version__ = '2.0.2'
 type_mapping = {
     'synapse': SynapseSchema,
     'fly_synapse': BuhmannSynapseSchema,
-    'fly_nt_synapse': BuhmannSynapseSchema,
+    'fly_nt_synapse': BuhmannEcksteinSchema,
     'presynaptic_bouton_type': PresynapticBoutonType,
     'postsynaptic_compartment': PostsynapticCompartment,
     'microns_func_coreg': FunctionalCoregistration,

--- a/emannotationschemas/__init__.py
+++ b/emannotationschemas/__init__.py
@@ -1,4 +1,4 @@
-from emannotationschemas.synapse import SynapseSchema, PlasticSynapse, BuhmannSynapseSchema, BuhmannEcksteinSchema
+from emannotationschemas.synapse import SynapseSchema, PlasticSynapse, BuhmannSynapseSchema, BuhmannEcksteinSynapseSchema
 from emannotationschemas.errors import UnknownAnnotationTypeException
 from emannotationschemas.flatten import create_flattened_schema
 from emannotationschemas.presynaptic_bouton_type import PresynapticBoutonType
@@ -15,7 +15,7 @@ __version__ = '2.0.2'
 type_mapping = {
     'synapse': SynapseSchema,
     'fly_synapse': BuhmannSynapseSchema,
-    'fly_nt_synapse': BuhmannEcksteinSchema,
+    'fly_nt_synapse': BuhmannEcksteinSynapseSchema,
     'presynaptic_bouton_type': PresynapticBoutonType,
     'postsynaptic_compartment': PostsynapticCompartment,
     'microns_func_coreg': FunctionalCoregistration,

--- a/emannotationschemas/__init__.py
+++ b/emannotationschemas/__init__.py
@@ -1,4 +1,4 @@
-from emannotationschemas.synapse import SynapseSchema, PlasticSynapse
+from emannotationschemas.synapse import SynapseSchema, PlasticSynapse, BuhmannSynapseSchema
 from emannotationschemas.errors import UnknownAnnotationTypeException
 from emannotationschemas.flatten import create_flattened_schema
 from emannotationschemas.presynaptic_bouton_type import PresynapticBoutonType
@@ -14,6 +14,8 @@ __version__ = '2.0.2'
 
 type_mapping = {
     'synapse': SynapseSchema,
+    'fly_synapse': BuhmannSynapseSchema,
+    'fly_nt_synapse': BuhmannSynapseSchema,
     'presynaptic_bouton_type': PresynapticBoutonType,
     'postsynaptic_compartment': PostsynapticCompartment,
     'microns_func_coreg': FunctionalCoregistration,

--- a/emannotationschemas/synapse.py
+++ b/emannotationschemas/synapse.py
@@ -50,11 +50,11 @@ class BuhmannSynapseSchema(BaseSynapseSchema):
 
 class BuhmannEcksteinSynapseSchema(BuhmannSynapseSchema):
     gaba = mm.fields.Float(description="Gaba probability by Eckstein et al. 2020")
-    acetylcholine = mm.fields.Float(description="Acetylcholine probability by Eckstein et al. 2020")
-    glutamate = mm.fields.Float(description="Glutamate probability by Eckstein et al. 2020")
-    octopamine = mm.fields.Float(description="Octopamine probability by Eckstein et al. 2020")
-    serotonin = mm.fields.Float(description="Serotonin probability by Eckstein et al. 2020")
-    dopamine = mm.fields.Float(description="Dopamine probability by Eckstein et al. 2020")
+    ach = mm.fields.Float(description="Acetylcholine probability by Eckstein et al. 2020")
+    gut = mm.fields.Float(description="Glutamate probability by Eckstein et al. 2020")
+    oct = mm.fields.Float(description="Octopamine probability by Eckstein et al. 2020")
+    ser = mm.fields.Float(description="Serotonin probability by Eckstein et al. 2020")
+    da = mm.fields.Float(description="Dopamine probability by Eckstein et al. 2020")
     valid_nt = mm.fields.Bool(description="False = no neurotransmitter prediction available.")
 
 

--- a/emannotationschemas/synapse.py
+++ b/emannotationschemas/synapse.py
@@ -51,7 +51,7 @@ class BuhmannSynapseSchema(BaseSynapseSchema):
 class BuhmannEcksteinSynapseSchema(BuhmannSynapseSchema):
     gaba = mm.fields.Float(description="Gaba probability by Eckstein et al. 2020")
     ach = mm.fields.Float(description="Acetylcholine probability by Eckstein et al. 2020")
-    gut = mm.fields.Float(description="Glutamate probability by Eckstein et al. 2020")
+    glut = mm.fields.Float(description="Glutamate probability by Eckstein et al. 2020")
     oct = mm.fields.Float(description="Octopamine probability by Eckstein et al. 2020")
     ser = mm.fields.Float(description="Serotonin probability by Eckstein et al. 2020")
     da = mm.fields.Float(description="Dopamine probability by Eckstein et al. 2020")

--- a/emannotationschemas/synapse.py
+++ b/emannotationschemas/synapse.py
@@ -4,17 +4,13 @@ from emannotationschemas.base import BoundSpatialPoint, \
 import marshmallow as mm
 
 
-class SynapseSchema(AnnotationSchema):
+class BaseSynapseSchema(AnnotationSchema):
     pre_pt = mm.fields.Nested(BoundSpatialPoint, required=True,
                               description="presynaptic point",
                               order=0)
-    ctr_pt = mm.fields.Nested(SpatialPoint, required=True,
-                              description="central point",
-                              order=1)
     post_pt = mm.fields.Nested(BoundSpatialPoint, required=True,
                                description="presynaptic point",
                                order=2)
-    size = mm.fields.Float(description="size of synapse")
 
     @mm.post_load
     def validate_type(self, item):
@@ -37,6 +33,29 @@ class SynapseSchema(AnnotationSchema):
         else:
             item.pop('valid', None)
         return item
+
+class SynapseSchema(BaseSynapseSchema):
+    ctr_pt = mm.fields.Nested(SpatialPoint, required=True,
+                              description="central point",
+                              order=1)
+    size = mm.fields.Float(description="size of synapse")
+
+
+class BuhmannSynapseSchema(BaseSynapseSchema):
+    score = mm.fields.Float(description="score assigned by Buhmann et al. 2019")
+    cleft_score = mm.fields.Float(description="score derived by Buhmann et al. 2019 " \
+                                  "by combining their synapses with the synapse " \
+                                  "segmentation from Heinrich et al. 2018")
+
+
+class BuhmannEcksteinSchema(BuhmannSynapseSchema):
+    gaba = mm.fields.Float(description="Gaba probability by Eckstein et al. 2020")
+    acetylcholine = mm.fields.Float(description="Acetylcholine probability by Eckstein et al. 2020")
+    glutamate = mm.fields.Float(description="Glutamate probability by Eckstein et al. 2020")
+    octopamine = mm.fields.Float(description="Octopamine probability by Eckstein et al. 2020")
+    serotonin = mm.fields.Float(description="Serotonin probability by Eckstein et al. 2020")
+    dopamine = mm.fields.Float(description="Dopamine probability by Eckstein et al. 2020")
+    valid_nt = mm.fields.Bool(description="False = no neurotransmitter prediction available.")
 
 
 class PlasticSynapse(SynapseSchema):

--- a/emannotationschemas/synapse.py
+++ b/emannotationschemas/synapse.py
@@ -48,7 +48,7 @@ class BuhmannSynapseSchema(BaseSynapseSchema):
                                   "segmentation from Heinrich et al. 2018")
 
 
-class BuhmannEcksteinSchema(BuhmannSynapseSchema):
+class BuhmannEcksteinSynapseSchema(BuhmannSynapseSchema):
     gaba = mm.fields.Float(description="Gaba probability by Eckstein et al. 2020")
     acetylcholine = mm.fields.Float(description="Acetylcholine probability by Eckstein et al. 2020")
     glutamate = mm.fields.Float(description="Glutamate probability by Eckstein et al. 2020")


### PR DESCRIPTION
- Reorganized the synapse schema to allow synapses with two locations instead of three
- neurotransmitter scores use float fields but we should evaluate the use of 8bit fields