### PR TITLE
Proofreading status

### DIFF
--- a/emannotationschemas/__init__.py
+++ b/emannotationschemas/__init__.py
@@ -1,3 +1,4 @@
+from emannotationschemas.schemas.neuron_proofreading import NeuronProofreadStatus
 from emannotationschemas.schemas.synapse import SynapseSchema
 from emannotationschemas.schemas.synapse import PlasticSynapse
 from emannotationschemas.schemas.synapse import BuhmannSynapseSchema
@@ -13,6 +14,7 @@ from emannotationschemas.schemas.contact import Contact
 from emannotationschemas.schemas.extended_classical_cell_type import ExtendedClassicalCellType
 from emannotationschemas.schemas.nucleus_detection import NucleusDetection
 from emannotationschemas.schemas.derived_spatial_point import DerivedSpatialPoint, DerivedTag
+from emannotationschemas.schemas.proofreading import NeuronProofreadStatus, ProofreadStatus
 from emannotationschemas.errors import UnknownAnnotationTypeException
 from emannotationschemas.flatten import create_flattened_schema
 
@@ -35,6 +37,8 @@ type_mapping = {
     'contact': Contact,
     'derived_spatial_point': DerivedSpatialPoint,
     'derived_tag': DerivedTag,
+    'proofread_status': ProofreadStatus,
+    'neuron_proofread_status': NeuronProofreadStatus,
 }
 
 

--- a/emannotationschemas/__init__.py
+++ b/emannotationschemas/__init__.py
@@ -1,4 +1,3 @@
-from emannotationschemas.schemas.neuron_proofreading import NeuronProofreadStatus
 from emannotationschemas.schemas.synapse import SynapseSchema
 from emannotationschemas.schemas.synapse import PlasticSynapse
 from emannotationschemas.schemas.synapse import BuhmannSynapseSchema
@@ -14,7 +13,7 @@ from emannotationschemas.schemas.contact import Contact
 from emannotationschemas.schemas.extended_classical_cell_type import ExtendedClassicalCellType
 from emannotationschemas.schemas.nucleus_detection import NucleusDetection
 from emannotationschemas.schemas.derived_spatial_point import DerivedSpatialPoint, DerivedTag
-from emannotationschemas.schemas.proofreading import NeuronProofreadStatus, ProofreadStatus
+from emannotationschemas.schemas.proofreading import CompartmentProofreadStatus, ProofreadStatus
 from emannotationschemas.errors import UnknownAnnotationTypeException
 from emannotationschemas.flatten import create_flattened_schema
 
@@ -38,7 +37,7 @@ type_mapping = {
     'derived_spatial_point': DerivedSpatialPoint,
     'derived_tag': DerivedTag,
     'proofread_status': ProofreadStatus,
-    'neuron_proofread_status': NeuronProofreadStatus,
+    'compartment_proofread_status': CompartmentProofreadStatus,
 }
 
 

--- a/emannotationschemas/schemas/proofreading.py
+++ b/emannotationschemas/schemas/proofreading.py
@@ -6,6 +6,7 @@ from emannotationschemas.schemas.base import (
 )
 
 proofread_choices = ["non", "clean", "extended"]
+options_text = "Options are: 'non' to indicate no comprehensive proofreading, 'clean' to indicate comprehensive removal of false merges, and 'extended' to mean comprehensive extension of neurite tips"
 
 
 class PointWithValid(AnnotationSchema):
@@ -24,18 +25,18 @@ class ProofreadStatus(PointWithValid):
     status = fields.String(
         required=True,
         validate=validate.OneOf(proofread_choices),
-        description="Proofread status of cell",
+        description=f"Proofread status of cell. {options_text}",
     )
 
 
-class NeuronProofreadStatus(PointWithValid):
+class CompartmentProofreadStatus(PointWithValid):
     status_dendrite = fields.String(
         required=True,
         validate=validate.OneOf(proofread_choices),
-        description="Proofread status of a cell dendrite",
+        description=f"Proofread status of the dendrite only. {options_text}",
     )
     status_axon = fields.String(
         required=True,
         validate=validate.OneOf(proofread_choices),
-        description="Proofread status of a cell axon",
+        description=f"Proofread status of the axon only. {options_text}",
     )

--- a/emannotationschemas/schemas/proofreading.py
+++ b/emannotationschemas/schemas/proofreading.py
@@ -1,0 +1,41 @@
+from marshmallow import fields, validate
+from emannotationschemas.schemas.base import (
+    BoundSpatialPoint,
+    AnnotationSchema,
+    NumericField,
+)
+
+proofread_choices = ["non", "clean", "extended"]
+
+
+class PointWithValid(AnnotationSchema):
+    pt = fields.Nested(
+        BoundSpatialPoint,
+        required=True,
+        description="Core location on proofread object",
+    )
+    valid_root_id = NumericField(
+        required=True,
+        description="Root id of the object when proofread status was assigned. If the pt_root_id of the cell differs, the proofreading status may not apply.",
+    )
+
+
+class ProofreadStatus(PointWithValid):
+    status = fields.String(
+        required=True,
+        validate=validate.OneOf(proofread_choices),
+        description="Proofread status of cell",
+    )
+
+
+class NeuronProofreadStatus(PointWithValid):
+    status_dendrite = fields.String(
+        required=True,
+        validate=validate.OneOf(proofread_choices),
+        description="Proofread status of a cell dendrite",
+    )
+    status_axon = fields.String(
+        required=True,
+        validate=validate.OneOf(proofread_choices),
+        description="Proofread status of a cell axon",
+    )

--- a/tests/test_proofreading_schema.py
+++ b/tests/test_proofreading_schema.py
@@ -1,0 +1,54 @@
+from emannotationschemas.schemas.proofreading import (
+    ProofreadStatus,
+    CompartmentProofreadStatus,
+)
+import pytest
+from marshmallow import ValidationError
+
+good_base_data = {
+    "pt": {"position": [1, 2, 3]},
+    "valid_root_id": 1234567,
+    "status": "clean",
+}
+
+bad_base_data = {
+    "pt": {"position": [1, 2, 3]},
+    "valid_root_id": 1234567,
+    "status": "some_nonsense",
+}
+
+good_comp_data = {
+    "pt": {"position": [1, 2, 3]},
+    "valid_root_id": 1234567,
+    "status_axon": "clean",
+    "status_dendrite": "extended",
+}
+
+bad_comp_data = {
+    "pt": {"position": [1, 2, 3]},
+    "valid_root_id": 1234567,
+    "status_dendrite": "clean",
+}
+
+
+def annotation_import(item):
+    item["supervoxel_id"] = None
+    item.pop("rootId", None)
+
+
+def test_proofreading_validation():
+    schema = ProofreadStatus(context={"bsp_fn": annotation_import})
+    result = schema.load(good_base_data)
+    assert result["status"] == "clean"
+
+    with pytest.raises(ValidationError):
+        schema.load(bad_base_data)
+
+
+def test_compartment_proofreading_validation():
+    schema = CompartmentProofreadStatus(context={"bsp_fn": annotation_import})
+    result = schema.load(good_comp_data)
+    assert result["status_dendrite"] == "extended"
+
+    with pytest.raises(ValidationError):
+        schema.load(bad_comp_data)


### PR DESCRIPTION
Proposal for a proofreading status schema. For the use case we have in mind for cortical data, we want to separate axonal and dendritic proofreading, however for other data (e.g. fly) this may be less relevant. To accommodate both, I added both a CompartmentProofreadingStatus with both axon/dendrite status and a basic ProofreadingStatus with a single status.