### PR TITLE
Add bound point reference annotation

### DIFF
--- a/emannotationschemas/__init__.py
+++ b/emannotationschemas/__init__.py
@@ -11,7 +11,10 @@ from emannotationschemas.schemas.functional_coregistration import (
     FunctionalUnitCoregistrationExtended,
 )
 from emannotationschemas.schemas.postsynaptic_compartment import PostsynapticCompartment
-from emannotationschemas.schemas.base import FlatSegmentationReferenceSinglePoint
+from emannotationschemas.schemas.base import (
+    FlatSegmentationReferenceSinglePoint,
+    ReferenceBoundSpatialPoint,
+)
 from emannotationschemas.schemas.cell_type_local import CellTypeLocal, CellTypeReference
 from emannotationschemas.schemas.bound_text_tag import (
     BoundTagAnnotation,
@@ -71,6 +74,7 @@ type_mapping = {
     "compartment_proofread_status": CompartmentProofreadStatus,
     "proofreading_boolstatus_user": ProofreadingBoolStatusUser,
     "fly_neuropil": FlyNeuropil,
+    "reference_point": ReferenceBoundSpatialPoint,
 }
 
 

--- a/emannotationschemas/schemas/base.py
+++ b/emannotationschemas/schemas/base.py
@@ -137,6 +137,10 @@ class BoundSpatialPoint(SpatialPoint):
         return item
 
 
+class ReferenceBoundSpatialPoint(ReferenceAnnotation, BoundSpatialPoint):
+    """Bound spatial point reference to another annotation"""
+
+
 class FlatSegmentationReferenceSinglePoint(FlatSegmentationReference):
     pt = mm.fields.Nested(
         BoundSpatialPoint,


### PR DESCRIPTION
Adding a bound point reference annotation. This can allow, for example, alternative segmentation lookup points for nuclei that fell badly in the original segmentation.