### PR TITLE
Adds new proofreading schema

### DIFF
--- a/emannotationschemas/schemas/proofreading.py
+++ b/emannotationschemas/schemas/proofreading.py
@@ -2,11 +2,12 @@ from emannotationschemas.schemas.base import (
     AnnotationSchema,
     BoundSpatialPoint,
     NumericField,
+    ReferenceAnnotation
 )
 from marshmallow import fields, validate
 
-proofread_choices = ["non", "clean", "extended"]
-options_text = "Options are: 'non' to indicate no comprehensive proofreading, 'clean' to indicate comprehensive removal of false merges, and 'extended' to mean comprehensive extension of neurite tips"
+proofread_choices = ["non", "clean", "extended", "roughly clean", "roughly extended"]
+options_text = "Options are: 'non' to indicate no comprehensive proofreading, 'clean' to indicate comprehensive removal of false merges, 'roughly clean' to indicate partial removal of false merges, 'extended' to indicate comprehensive extension of neurite tips, and 'roughly extended' to indicate partial extension of neurite tips."
 
 
 class PointWithValid(AnnotationSchema):
@@ -53,4 +54,20 @@ class ProofreadingBoolStatusUser(ProofreadingBoolStatus):
     user_id = fields.Int(
         required=True,
         description="User who assessed the proofreading status.",
+    )
+
+class CompartmentProofreadStatusReference(ReferenceAnnotation):
+    user_id = fields.Int(
+        required=False,
+        description="User who assessed the proofreading status.",
+    )
+    status_dendrite = fields.String(
+        required=True,
+        validate=validate.OneOf(proofread_choices),
+        description=f"Proofread status of the dendrite only. {options_text}",
+    )
+    status_axon = fields.String(
+        required=True,
+        validate=validate.OneOf(proofread_choices),
+        description=f"Proofread status of the axon only. {options_text}",
     )


### PR DESCRIPTION
- This new schema would be used for reference tables with the `target_id` as a foreign key to the nucleus id in nucleus_neuron_svm. 
- Also adds 'roughly clean' and 'roughly extended' to the proofreading status enum to track neurons that have gone through some rounds of proofreading but are not comprehensively clean or extended. 
- Let me know if you'd like test cases added before merging. 