### PR TITLE
Remove reference tag with confidence

### DIFF
--- a/emannotationschemas/schemas/base.py
+++ b/emannotationschemas/schemas/base.py
@@ -216,12 +216,3 @@ class ReferenceInteger(ReferenceAnnotation):
         required=True,
         description="Integer value to be attached to the annotation",
     )
-
-
-class ReferenceTagWithConfidence(ReferenceAnnotation):
-    """Reference annotation with a float value describing confidence in the tag"""
-
-    confidence = mm.fields.Float(
-        required=True,
-        description="Confidence value to be attached to the annotation",
-    )


### PR DESCRIPTION
I somehow missed that this exists https://github.com/CAVEconnectome/EMAnnotationSchemas/blob/45dce92737ce4d469d708cfe1ed0818c3f7df095/emannotationschemas/schemas/reference_text_float.py#L6 so I don't think we need the confidence one, this is already what I wanted