### PR TITLE
Add reference_double_float and reference_triple_float schemas

### DIFF
--- a/emannotationschemas/__init__.py
+++ b/emannotationschemas/__init__.py
@@ -71,6 +71,10 @@ from emannotationschemas.schemas.proofreading import (
     ProofreadingBoolStatusUser,
     ProofreadStatus,
 )
+from emannotationschemas.schemas.reference_float import (
+    ReferenceDoubleFloat,
+    ReferenceTripleFloat,
+)
 from emannotationschemas.schemas.reference_text_float import (
     ReferenceTagFloat,
 )
@@ -138,6 +142,8 @@ type_mapping = {
     "pt_bool_valid": SpatialPointBoolWithValid,
     "reference_integer": ReferenceInteger,
     "reference_tag_float": ReferenceTagFloat,
+    "reference_double_float": ReferenceDoubleFloat,
+    "reference_triple_float": ReferenceTripleFloat,
     "compartment_proofread_status_strategy": CompartmentProofreadStatusStrategy,
     "reference_tag_with_confidence": ReferenceTagWithConfidence,
     "digital_twin_properties": DigitalTwinPropertiesBCM,

--- a/emannotationschemas/schemas/reference_float.py
+++ b/emannotationschemas/schemas/reference_float.py
@@ -1,0 +1,24 @@
+import marshmallow as mm
+
+from emannotationschemas.schemas.base import ReferenceAnnotation
+
+
+class ReferenceDoubleFloat(ReferenceAnnotation):
+    value = mm.fields.Float(
+        required=True, description="First float value attached to the annotation"
+    )
+    value2 = mm.fields.Float(
+        required=True, description="Second float value attached to the annotation"
+    )
+
+
+class ReferenceTripleFloat(ReferenceAnnotation):
+    value = mm.fields.Float(
+        required=True, description="First float value attached to the annotation"
+    )
+    value2 = mm.fields.Float(
+        required=True, description="Second float value attached to the annotation"
+    )
+    value3 = mm.fields.Float(
+        required=True, description="Third float value attached to the annotation"
+    )

--- a/tests/test_reference_float_schema.py
+++ b/tests/test_reference_float_schema.py
@@ -1,0 +1,40 @@
+import pytest
+from marshmallow import ValidationError
+
+from emannotationschemas import get_schema, get_types
+from emannotationschemas.schemas.reference_float import (
+    ReferenceDoubleFloat,
+    ReferenceTripleFloat,
+)
+
+target_id = 1
+
+
+def test_reference_double_float():
+    result = ReferenceDoubleFloat().load(
+        {"target_id": target_id, "value": 0.5, "value2": 1.5}
+    )
+    assert result["target_id"] == target_id
+    assert result["value"] == 0.5
+    assert result["value2"] == 1.5
+
+
+def test_reference_triple_float():
+    result = ReferenceTripleFloat().load(
+        {"target_id": target_id, "value": 0.1, "value2": 0.2, "value3": 0.3}
+    )
+    assert result["value"] == 0.1
+    assert result["value2"] == 0.2
+    assert result["value3"] == 0.3
+
+
+def test_reference_double_float_missing_value():
+    with pytest.raises(ValidationError):
+        ReferenceDoubleFloat().load({"target_id": target_id, "value": 0.5})
+
+
+def test_registered_in_type_mapping():
+    assert get_schema("reference_double_float") is ReferenceDoubleFloat
+    assert get_schema("reference_triple_float") is ReferenceTripleFloat
+    assert "reference_double_float" in get_types()
+    assert "reference_triple_float" in get_types()


### PR DESCRIPTION
## 🧔‍♂️Summary
I have three distinct "scores" for each of my synapses. Right now I use one `reference_float` table for each of those, but it's causing a lot of bloat.  As I see it, I currently have 3 options:


option | synapse table | score storage | total | Δ vs no-scores
-- | -- | -- | -- | --
synapse, no scores | 64 | 0 | 64 GB | —
new schema, 3 scores baked in | ~67 (64 + ~3) | in-row | ~67 GB | +3 GB
synapse + 1 ref table (3 scores) | 64 | ~25 | ~89 GB | +25 GB
synapse + 3 ref tables (current) | 64 | ~73 | ~137 GB | +73 GB

Not sure what the best approach is. The scoring system might change in the future (new column names, more or fewer columns), so I don't really want to create a new synapse schema, and a schema with column names specifically for this scored synapse table won't be of any use to anybody else (including future me)...

So I think the best short-term compromise is have a generic `reference_triple_float` column, which helps a bit with storage size and has some reuseability, I hope?

-----


## 🤖 Summary
Adds two reference annotation schemas for attaching a **pair** or **triple** of float
values to another annotation — e.g. multiple per-synapse scores (detection mean/median +
assignment confidence) — complementing the existing single-value `reference_tag_float`.

- `ReferenceDoubleFloat` → `reference_double_float` (`value`, `value2`)
- `ReferenceTripleFloat` → `reference_triple_float` (`value`, `value2`, `value3`)

Both subclass `ReferenceAnnotation` (so they carry `target_id` + `valid`, no `tag`) and are
registered in `type_mapping`. The `value` / `value2` / `value3` naming follows the existing
multi-field convention (e.g. `bound_double_tag`'s `tag` / `tag2`).

## Motivation
Storing N independent floats per annotation currently needs N separate `reference_tag_float`
tables — one row plus full annotation overhead per value. A single multi-float reference
collapses that into one row, materially reducing storage and query overhead when every target
annotation carries the same fixed set of scalars.

## Changes
- `emannotationschemas/schemas/reference_float.py` — the two schema classes
- `emannotationschemas/__init__.py` — imports + `type_mapping` entries
- `tests/test_reference_float_schema.py` — load/validation + registry tests

## Testing
The 4 new tests pass, and flattening yields the expected columns:
- `reference_double_float` → `target_id, valid, value, value2`
- `reference_triple_float` → `target_id, valid, value, value2, value3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
